### PR TITLE
Add Laravel 12 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,9 +9,9 @@
     "consul"
   ],
   "require": {
-    "illuminate/support": "^7|^8|^9|^10",
+    "illuminate/support": "^7|^8|^9|^10|^11|^12",
     "dcarbone/php-consul-api": "^1.0",
-    "illuminate/console": "^7|^8|^9|^10"
+    "illuminate/console": "^7|^8|^9|^10|^11|^12"
   },
   "license": "MIT",
   "authors": [


### PR DESCRIPTION
Added Laravel 12 support

- Updated composer.json to support illuminate/* v11 and v12
- Tested on fresh Laravel 12 app
- Service provider and command working correctly